### PR TITLE
Updated podspec to support new parse updates

### DIFF
--- a/Parse-ReactiveCocoa.podspec
+++ b/Parse-ReactiveCocoa.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.source_files   = '*.{h,m}'  
   s.platform       = :ios, '7.0'
   s.requires_arc = true
-  s.dependency 'Parse', '~> 1.7.2.1'
+  s.dependency 'Parse', '~> 1.7.2'
   s.dependency 'ReactiveCocoa', '~> 2.5'
   s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '"${PODS_ROOT}/Parse"' }
 end


### PR DESCRIPTION
Supported versions include anything between 1.7.2 and 1.8 but not including 1.8.